### PR TITLE
Fix jq: error (at <stdin>:1): Cannot index string with string "find"

### DIFF
--- a/input/envs.json
+++ b/input/envs.json
@@ -14,8 +14,10 @@
       "deployment": "enterprise"
     }
   ],
-  "discrete": {
-    "master": "prod",
-    "minions": "dev|stage|qa"
-  }
+  "discrete": [
+    {
+      "master": "prod",
+      "minions": "dev|stage|qa"
+    }
+  ]
 }

--- a/input/envs.json
+++ b/input/envs.json
@@ -16,8 +16,8 @@
   ],
   "discrete": [
     {
-      "master": "prod",
-      "minions": "dev|stage|qa"
+      "find": "foo|bar",
+      "replace_with": "car"
     }
   ]
 }


### PR DESCRIPTION
The existing example env.json is incorrect:

discrete needs to be an array or you will get "jq: error (at <stdin>:1): Cannot index string with string "find"" in kong_gateway_fetch_workspace_services (line 266)